### PR TITLE
KAS-3014 VO Header en footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ COPY . .
 RUN ember build -prod
 
 FROM semtech/ember-proxy-service:1.5.1
-ENV EMBER_VO_HEADER=""
-ENV EMBER_VO_FOOTER=""
+ENV EMBER_VO_HEADER_WIDGET_URL=""
+ENV EMBER_VO_FOOTER_WIDGET_URL=""
 
 ENV STATIC_FOLDERS_REGEX "^/(assets|fonts|files|ember-pdfjs-wrapper)/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ COPY . .
 RUN ember build -prod
 
 FROM semtech/ember-proxy-service:1.5.1
-ENV EMBER_VO_HEADER="//tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199/embed"
-ENV EMBER_VO_FOOTER="//tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199/embed"
+ENV EMBER_VO_HEADER="https://tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199"
+ENV EMBER_VO_FOOTER="https://tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199"
 
 ENV STATIC_FOLDERS_REGEX "^/(assets|fonts|files|ember-pdfjs-wrapper)/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ COPY . .
 RUN ember build -prod
 
 FROM semtech/ember-proxy-service:1.5.1
-ENV EMBER_VO_HEADER="https://tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199"
-ENV EMBER_VO_FOOTER="https://tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199"
+ENV EMBER_VO_HEADER=""
+ENV EMBER_VO_FOOTER=""
 
 ENV STATIC_FOLDERS_REGEX "^/(assets|fonts|files|ember-pdfjs-wrapper)/"
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,21 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Deploying
 
-Specify what it takes to deploy your app.
+#### VO header/footer widget details
+
+Test environment:
+```
+environment:
+  EMBER_VO_HEADER_WIDGET_URL: "https://tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/3bcc4b26-e216-489c-8f11-cd9299f08199"
+  EMBER_VO_FOOTER_WIDGET_URL: "https://tni.widgets.burgerprofiel.dev-vlaanderen.be/api/v1/widget/7eed3599-96aa-435b-bc43-fe13d2fc0531"
+```
+
+Production environment:
+```
+environment:
+  EMBER_VO_HEADER_WIDGET_URL: "https://prod.widgets.burgerprofiel.vlaanderen.be/api/v1/widget/9e21cea6-b1a6-48fe-9322-8296c138b24b"
+  EMBER_VO_FOOTER_WIDGET_URL: "https://prod.widgets.burgerprofiel.vlaanderen.be/api/v1/widget/f2907451-e337-41f2-9740-ab421226fdad"
+```
 
 ## Further Reading / Useful Links
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -2,9 +2,24 @@ import Controller from '@ember/controller';
 import ENV from 'frontend-valvas/config/environment';
 
 export default class ApplicationController extends Controller {
-  constructor() {
-    super(...arguments);
-    this.header = ENV['vo-webuniversum']['header'];
-    this.footer = ENV['vo-webuniversum']['footer'];
+  VO_HEADER_WIDGET_URL = ENV.VO_HEADER_WIDGET_URL;
+  VO_FOOTER_WIDGET_URL = ENV.VO_FOOTER_WIDGET_URL;
+
+  get hasExternallySourcedHeader() {
+    try {
+      new URL(ENV.VO_HEADER_WIDGET_URL);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  get hasExternallySourcedFooter() {
+    try {
+      new URL(ENV.VO_FOOTER_WIDGET_URL);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 }

--- a/app/modifiers/vl-widget.js
+++ b/app/modifiers/vl-widget.js
@@ -1,7 +1,10 @@
+/*global vl*/
 import { modifier } from 'ember-modifier';
 
 export default modifier((element, [url]) => {
-  vl.widget.client.bootstrap(url).then(function(widget) {
+  // From https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/2327449182/Technische+documentatie+Widget-platform#Een-widget-toevoegen-aan-een-webpagina-via-Javascript
+  // (visited on 25/10/2021)
+  vl.widget.client.bootstrap(url).then(function (widget) {
     return widget.setMountElement(element).mount();
   });
 });

--- a/app/styles/_vo-widget.scss
+++ b/app/styles/_vo-widget.scss
@@ -3,19 +3,58 @@ Extract adapted from
 https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/2604728345/Tools+om+de+header+en+branding+te+previewen
 */
 .l-external-header {
+
+  /* LEFT ICON IN HEADER */
+  .vlw .vlw__primary-bar__brand__umbrella--secondary::before,
+  .vlw .vlw__primary-bar__brand__umbrella--secondary::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 28px;
+    height: 100%;
+    background: $yellow;
+  }
+
+  .vlw .vlw__primary-bar__brand__umbrella--secondary::after,
+  .vlw .vlw__primary-bar__brand__umbrella--secondary::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 28px;
+    width: 0;
+    height: 0;
+    background: none;
+    transform: none;
+    -ms-transform: none;
+    border-top: 43px solid transparent;
+    border-bottom: 0 solid transparent;
+    border-left: 13.5px solid $yellow;
+  }
+
   /* TEKST "HULP NODIG" */
   .vlw .vlw__contact--primary .vlw__contact__toggle::after,
   .vlw .vlw__contact--secondary .vlw__contact__toggle::after,
   .vlw .vlw__contact--tertiary .vlw__contact__toggle::after,
   .vlw .vlw__contact--quaternary .vlw__contact__toggle::after {
-    border-right: $white;
+    border-right: $yellow;
   }
 
   .vlw .vlw__contact--primary .vlw__contact__toggle,
   .vlw .vlw__contact--secondary .vlw__contact__toggle,
   .vlw .vlw__contact--tertiary .vlw__contact__toggle,
-  .vlw .vlw__contact--quaternary .vlw__contact__toggle {
-    background: $white;
+  .vlw .vlw__contact--quaternary .vlw__contact__toggle,
+  .vlw .vlw__contact--primary .vlw__contact__toggle:hover,
+  .vlw .vlw__contact--secondary .vlw__contact__toggle:hover,
+  .vlw .vlw__contact--tertiary .vlw__contact__toggle:hover,
+  .vlw .vlw__contact--quaternary .vlw__contact__toggle:hover,
+  .vlw .vlw__contact--primary .vlw__contact__toggle:focus,
+  .vlw .vlw__contact--secondary .vlw__contact__toggle:focus,
+  .vlw .vlw__contact--tertiary .vlw__contact__toggle:focus,
+  .vlw .vlw__contact--quaternary .vlw__contact__toggle:focus {
+    background: $yellow;
   }
 
   /* PROGRESS BAR */

--- a/app/styles/_vo-widget.scss
+++ b/app/styles/_vo-widget.scss
@@ -1,0 +1,25 @@
+/*
+Extract adapted from
+https://vlaamseoverheid.atlassian.net/wiki/spaces/IKPubliek/pages/2604728345/Tools+om+de+header+en+branding+te+previewen
+*/
+.l-external-header {
+  /* TEKST "HULP NODIG" */
+  .vlw .vlw__contact--primary .vlw__contact__toggle::after,
+  .vlw .vlw__contact--secondary .vlw__contact__toggle::after,
+  .vlw .vlw__contact--tertiary .vlw__contact__toggle::after,
+  .vlw .vlw__contact--quaternary .vlw__contact__toggle::after {
+    border-right: $white;
+  }
+
+  .vlw .vlw__contact--primary .vlw__contact__toggle,
+  .vlw .vlw__contact--secondary .vlw__contact__toggle,
+  .vlw .vlw__contact--tertiary .vlw__contact__toggle,
+  .vlw .vlw__contact--quaternary .vlw__contact__toggle {
+    background: $white;
+  }
+
+  /* PROGRESS BAR */
+  .vlw .vlw__primary-bar__progress {
+    background: $yellow;
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -29,6 +29,7 @@ $icon-font-location: '/fonts/';
 @import 'govflanders/components/_link';
 @import 'govflanders/components/_loader';
 @import 'govflanders/components/_search';
+@import 'govflanders/components/_select';
 @import 'govflanders/components/_titles';
 @import 'govflanders/components/_typography';
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -4,55 +4,12 @@
 @import '_colors';
 $icon-font-location: '/fonts/';
 
-// Core (loaded from node_modules)
-// @import "node_modules/@govflanders/vl-ui-core/src/scss/_setting.scss";
-// @import "node_modules/@govflanders/vl-ui-core/src/scss/_tool.scss";
-// @import "node_modules/@govflanders/vl-ui-core/src/scss/_core.scss";
-// @import "node_modules/@govflanders/vl-ui-core/src/scss/_generic.scss";
-// @import "node_modules/@govflanders/vl-ui-core/src/scss/_element.scss";
-// @import "node_modules/@govflanders/vl-ui-core/src/scss/_object.scss";
-
 // Components (loaded locally to easily read source)
 @import 'govflanders/core/_setting.scss';
 @import 'govflanders/core/_tool.scss';
 @import 'govflanders/core/_generic.scss';
 @import 'govflanders/core/_element.scss';
 @import 'govflanders/core/_object.scss';
-
-// Components (loaded from node_modules)
-// @import "node_modules/@govflanders/vl-ui-accordion/src/scss/_accordion";
-// @import "node_modules/@govflanders/vl-ui-action-group/src/scss/_action-group.scss";
-// @import "node_modules/@govflanders/vl-ui-alert/src/scss/_alert";
-// @import "node_modules/@govflanders/vl-ui-autocomplete/src/scss/_autocomplete";
-// @import "node_modules/@govflanders/vl-ui-badge/src/scss/_badge";
-// @import "node_modules/@govflanders/vl-ui-button/src/scss/_button.scss";
-// @import "node_modules/@govflanders/vl-ui-checkbox/src/scss/_checkbox";
-// @import "node_modules/@govflanders/vl-ui-data-table/src/scss/_data-table";
-// @import "node_modules/@govflanders/vl-ui-datepicker/src/scss/_datepicker";
-// @import "node_modules/@govflanders/vl-ui-description-data/src/scss/_description-data";
-// @import "node_modules/@govflanders/vl-ui-document/src/scss/_document.scss";
-// @import "node_modules/@govflanders/vl-ui-form-message/src/scss/_form-message.scss";
-// @import "node_modules/@govflanders/vl-ui-form-structure/src/scss/_form-structure.scss";
-//@import "node_modules/@govflanders/vl-ui-icon/src/scss/_icon.scss";
-// @import "node_modules/@govflanders/vl-ui-info-tile/src/scss/_info-tile.scss";
-// @import "node_modules/@govflanders/vl-ui-input-addon/src/scss/_input-addon.scss";
-// @import "node_modules/@govflanders/vl-ui-input-field/src/scss/_input-field.scss";
-// @import "node_modules/@govflanders/vl-ui-link-list/src/scss/link-list";
-// @import "node_modules/@govflanders/vl-ui-link/src/scss/_link.scss";
-// @import "node_modules/@govflanders/vl-ui-loader/src/scss/_loader.scss";
-// @import "node_modules/@govflanders/vl-ui-modal/src/scss/_modal";
-// @import "node_modules/@govflanders/vl-ui-pager/src/scss/_pager";
-// @import "node_modules/@govflanders/vl-ui-pill-input/src/scss/_pill-input";
-// @import "node_modules/@govflanders/vl-ui-pill/src/scss/_pill";
-// @import "node_modules/@govflanders/vl-ui-popover/src/scss/_popover";
-// @import "node_modules/@govflanders/vl-ui-radio/src/scss/_radio";
-// @import "node_modules/@govflanders/vl-ui-search/src/scss/_search;
-// @import "node_modules/@govflanders/vl-ui-tabs/src/scss/_tabs";
-// @import "node_modules/@govflanders/vl-ui-textarea/src/scss/_textarea";
-// @import "node_modules/@govflanders/vl-ui-titles/src/scss/_titles";
-// @import "node_modules/@govflanders/vl-ui-typography/src/scss/_typography";
-// @import "node_modules/@govflanders/vl-ui-upload/src/scss/_upload";
-// @import "node_modules/@govflanders/vl-ui-input-group/src/scss/_input-group";
 
 // Components (loaded locally to easily read source)
 @import 'govflanders/components/_action-group';
@@ -75,14 +32,6 @@ $icon-font-location: '/fonts/';
 @import 'govflanders/components/_titles';
 @import 'govflanders/components/_typography';
 
-// Interdependent components (loaded from node_modules)
-// @import "node_modules/@govflanders/vl-ui-select/src/scss/_select";
-// @import "node_modules/@govflanders/vl-ui-select/src/scss/_js-select";
-
-// Interdependent components - These are source order dependent
-@import 'govflanders/components/_select';
-@import 'govflanders/components/_js-select';
-
 /* Unofficial code
       ========================================================================== */
 
@@ -104,9 +53,6 @@ $icon-font-location: '/fonts/';
 @import 'custom-components/vlc-content-header';
 @import 'custom-components/vlc-spotlight';
 
-// Imports utilities (loaded from node_modules)
-// @import "node_modules/@govflanders/vl-ui-util/src/scss/util";
-
 // Utilities (loaded locally to easily read source)
 @import 'govflanders/util/_util';
 
@@ -115,6 +61,28 @@ $icon-font-location: '/fonts/';
 @import 'custom-utilities/_extended-spacer';
 @import 'custom-utilities/_scroll';
 @import 'custom-utilities/_box-model';
+
+// SPECIFIC ADDITION (HEADER PLACEHOLDER)
+
+.l-external-header {
+  //
+}
+
+.l-external-header__placeholder {
+  width: 100%;
+  height: 43px;
+  background: #fff;
+
+  // When the supported browsers support the :has selector (https://developer.mozilla.org/en-US/docs/Web/CSS/:has) we can also add a shadow to the placeholder (now, we'll get double shadows otherwise)
+  // &:has(> .vlw) {
+  //   box-shadow: 0 1px 3px rgb(12 13 14 / 10%), 0 4px 20px rgb(12 13 14 / 4%), 0 1px 1px rgb(12 13 14 / 3%);
+  // }
+}
+
+// SPECIFIC ADDITION (AIV HEADER-WIDGET COLOR CUSTOMIZATION)
+@import "vo-widget";
+
+// SPECIFIC ADDITION
 
 body > #valvas-inner-body-wrapper {
   height: 100% !important;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,9 +1,16 @@
-<HeadLayout />
-<WuWidget @src={{this.header}} />
 {{page-title 'Beslissingen van de Vlaamse Regering | Vlaanderen.be'}}
+{{#if this.hasExternallySourcedHeader}}
+  <div class="l-external-header">
+    <div class="l-external-header__placeholder">
+      <header {{vl-widget this.VO_HEADER_WIDGET_URL}}></header>
+    </div>
+  </div>
+{{/if}}
 {{! Below wrapper element was introduced to stay compatible with the CSS that depended
   on pre-octane ember-view wrapping elements }}
 <div id='valvas-inner-body-wrapper'>
   {{outlet}}
 </div>
-<WuWidget @src={{this.footer}} />
+{{#if this.hasExternallySourcedFooter}}
+  <footer {{vl-widget this.VO_FOOTER_WIDGET_URL}}></footer>
+{{/if}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -26,10 +26,8 @@ module.exports = function (environment) {
       includeLocales: ['nl-be'],
       includeTimezone: 'all',
     },
-    'vo-webuniversum': {
-      header: '{{VO_HEADER}}',
-      footer: '{{VO_FOOTER}}',
-    },
+    VO_HEADER_WIDGET_URL: '{{VO_HEADER_WIDGET_URL}}',
+    VO_FOOTER_WIDGET_URL: '{{VO_FOOTER_WIDGET_URL}}',
   };
 
   if (environment === 'development') {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@govflanders/vl-widget-client": "^1.3.11",
+    "@govflanders/vl-widget-polyfill": "^1.3.11",
     "@lblod/ember-vo-webuniversum-widget": "^0.1.5",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
@@ -59,6 +61,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-math-helpers": "^2.15.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-modifier": "^2.1.2",
     "ember-moment": "^8.0.0",
     "ember-page-title": "^6.2.1",
     "ember-pdfjs-wrapper": "git+https://github.com/MikiDi/ember-pdfjs-wrapper.git#8300c671d3293dad0c5ccf87defdec6d08f839b3",
@@ -89,10 +92,5 @@
   },
   "ember": {
     "edition": "octane"
-  },
-  "dependencies": {
-    "@govflanders/vl-widget-client": "^1.3.11",
-    "@govflanders/vl-widget-polyfill": "^1.3.11",
-    "ember-modifier": "^2.1.2"
   }
 }


### PR DESCRIPTION
Header en footer zijn nog niet in orde aan de kant van de VO, maar we kunnen deze PR al mergen/releasen. Zolang er geen `EMBER_VO_{HEADER,FOOTER}_WIDGET_URL` environment variables ingesteld worden op de frontend container heeft deze change geen effect.

In vergelijking met frontend-themis:
- ook styling voor de progress-bar toegevoegd. Die verschijnt net onder de header als je naar beneden scrollt op een pagina. Indien geapproved in deze PR ook over te nemen in Themis.
- `!important` vermijden door custom styling te wrappen in `.l-external-header { ... }`