### PR TITLE
KAS-3463: Click statistieken voor beslissingenvlaamseregering

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,10 +1,23 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import ENV from 'frontend-valvas/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service moment;
+  @service plausible;
 
   beforeModel() {
     this.moment.setLocale('nl-be');
+    let { domain, apiHost } = ENV.plausible;
+
+    if (
+      domain !== '{{ANALYTICS_APP_DOMAIN}}' &&
+      apiHost !== '{{ANALYTICS_API_HOST}}'
+    ) {
+      return this.plausible.enable({
+        domain,
+        apiHost,
+      });
+    }
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -28,6 +28,13 @@ module.exports = function (environment) {
     },
     VO_HEADER_WIDGET_URL: '{{VO_HEADER_WIDGET_URL}}',
     VO_FOOTER_WIDGET_URL: '{{VO_FOOTER_WIDGET_URL}}',
+    'ember-plausible': {
+      enabled: false,
+    },
+    plausible: {
+      domain: '{{ANALYTICS_APP_DOMAIN}}',
+      apiHost: '{{ANALYTICS_API_HOST}}',
+    },
   };
 
   if (environment === 'development') {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ember-moment": "^8.0.0",
     "ember-page-title": "^6.2.1",
     "ember-pdfjs-wrapper": "git+https://github.com/MikiDi/ember-pdfjs-wrapper.git#8300c671d3293dad0c5ccf87defdec6d08f839b3",
+    "ember-plausible": "^0.1.0",
     "ember-promise-helpers": "^1.0.9",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",


### PR DESCRIPTION
This PR adds plausible support to Valvas' frontend.

To get it set up in a production environment, add the following two environment variables to the frontend container:

- `EMBER_ANALYTICS_APP_DOMAIN`: The domain, as defined in Plausible, that we want to gather analytics for. For Valvas that will probably be `beslissingenvlaamseregering.vlaanderen.be`.
- `EMBER_ANALYTICS_API_HOST`: URL pointing to the Plausible instance we will be reporting to. Still TBD where this will be.

When running locally on a dev machine, Plausible will be disabled. If you do need to enable it for testing purposes make the following changes:

```diff
diff --git a/app/routes/application.js b/app/routes/application.js
index 6ec9add..24a10b5 100644
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -17,6 +17,7 @@ export default class ApplicationRoute extends Route {
       return this.plausible.enable({
         domain,
         apiHost,
+        trackLocalhost: true,
       });
     }
   }
```

```diff
diff --git a/config/environment.js b/config/environment.js
index f99e7d5..0c04516 100644
--- a/config/environment.js
+++ b/config/environment.js
@@ -32,8 +32,8 @@ module.exports = function (environment) {
       enabled: false,
     },
     plausible: {
-      domain: '{{ANALYTICS_APP_DOMAIN}}',
-      apiHost: '{{ANALYTICS_API_HOST}}',
+      domain: 'the.domain.you.will.be.using.tld',
+      apiHost: 'https://the.url.to.plausible.tld',
     },
   };
 ```
