### PR TITLE
Featue/kas 3512 capture filters in plausible

### DIFF
--- a/app/controllers/newsitems/index.js
+++ b/app/controllers/newsitems/index.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class NewsitemsIndexController extends Controller {
   @service store;
   @service searchNewsItems;
+  @service plausible;
 
   queryParams = [
     'search',
@@ -91,5 +92,6 @@ export default class NewsitemsIndexController extends Controller {
   async loadMore() {
     await this.searchNewsItems.loadMore();
     this.groupNewsItemsByMeeting();
+    this.plausible.trackEvent('Laad meer');
   }
 }


### PR DESCRIPTION
Sends custom evens to Plausible whenever

- The "Laad meer" button is clicked
- The user performs a search with a set of filters (a single event is sent with all the chosen filters)

For the filters, some translation is made to make the received events somewhat easy to understand. E.g. the selected "Ministeriële bevoegdheid" is sent as a plaintext label instead of an ID.

The necessary changes in Plausible are creating two custom events, `Laad meer` and `Filter`. These were already created on the plausible instance used during the last demo session.