### PR TITLE
add styling for sub- and superscript

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -113,6 +113,16 @@ body > #valvas-inner-body-wrapper {
     list-style-type: revert;
     list-style-position: inside;
   }
+
+  sub {
+    vertical-align: sub;
+    font-size: smaller;
+  }
+
+  sup {
+    vertical-align: super;
+    font-size: smaller;
+  }
 }
 
 @media screen and (max-width: 767px) {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3907

Sub and superscript not showing correctly.
Before:
![image](https://user-images.githubusercontent.com/22245223/223413401-a187340f-695c-4e5c-95bb-780f6e0738ee.png)

After:
![image](https://user-images.githubusercontent.com/22245223/223413421-1297c409-306b-40e3-8abc-9e9569bdde23.png)
