### PR TITLE
fix styling for ul and ol

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -109,9 +109,13 @@ body > #valvas-inner-body-wrapper {
 }
 
 .decision__text {
+  ul {
+    list-style: disc;
+  }
+
   ul, ol {
+    margin-left: 2.4rem;
     list-style-type: revert;
-    list-style-position: inside;
   }
 }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3936

Lists are not showing correctly:
Currently only unordered `<ul>` are possible with rdfa-editor buttons but it is possible to copy paste ordered lists `<ol>`

### For **unordered** lists (bad example, the actual list is unordered but numbers were added manually ...
Before:
![image](https://user-images.githubusercontent.com/22245223/223414112-e5022c45-bc8b-4b40-9a0a-95cc8c6a07b3.png)

After:
![image](https://user-images.githubusercontent.com/22245223/223414138-a992fd3d-cfd9-42be-8b7c-9495d4546f5e.png)

### For ordered lists
Before:
![image](https://user-images.githubusercontent.com/22245223/223414297-30508f68-b1ca-48c2-ae6d-bd22bc04e73c.png)

After:
![image](https://user-images.githubusercontent.com/22245223/223414275-79674b6c-b210-4588-ae8a-59a3daecd350.png)
